### PR TITLE
Make control-sidebar transitions trigger a resize

### DIFF
--- a/inst/js/rightSidebar.js
+++ b/inst/js/rightSidebar.js
@@ -5,6 +5,12 @@ $(function () {
   var $selectedTab = $tabs.filter(".active");
   var $index = $selectedTab.index();
   
+  $(".control-sidebar").on('webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend',
+    function() {
+      $(window).trigger("resize");
+    }
+  );
+  
   //$('#right_sidebar .nav.nav-tabs li a').tab('show');
   
   //if ($selectedTab.length === 0) {


### PR DESCRIPTION
Unlike the main-sidebar, opening and closing the control-sidebar does currently not trigger plots to redraw/resize. This PR shows how to fix that. 

Here the corresponding code of how shinydashboard achieves this effect:

https://github.com/rstudio/shinydashboard/blob/281b9f2761c3504ed769a744b8520c8be35f1706/inst/shinydashboard.js#L87-L105

**NOTE**: I fixed it in my shiny app locally with the code snippet i propose here (so the snippet itself works), but note that I made this PR on github directly and thus technically did not test this PR