### PR TITLE
require styler 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Extend 'shinydashboard' with 'AdminLTE2' components.
 License: GPL (>= 2) | file LICENSE
 Imports: shiny, htmltools, shinydashboard
 Suggests:
-    styler (>= 1.0.2),
+    styler (>= 1.2.0),
     shinyAce,
     shinyWidgets,
     shinyEffects,


### PR DESCRIPTION
In particular because {{ is now recognized as rlang *curly curly*. Before, the line was broken between the two curly braces. Also, there were many other improvements over the last year. For details see https://github.com/r-lib/styler/releases/tag/v1.2.0.