### PR TITLE
dashboardUser: Handle output when title, subtitle, and body content are not used

### DIFF
--- a/R/dashboardHeaderPlus.R
+++ b/R/dashboardHeaderPlus.R
@@ -284,6 +284,23 @@ dashboardHeaderPlus <- function(..., title = NULL, titleWidth = NULL,
 dashboardUser <- function(..., name = NULL, src = NULL, title = NULL,
                           subtitle = NULL, footer = NULL) {
   
+  # Create line 1 for menu
+  if (!is.null(title)) {
+    line_1 <- paste0(name, " - ", title)
+  } else {
+    line_1 <- name
+  }
+  
+  # Create user_text based on if subtitle exists
+  # If subtitle doesn't exist, make the menu height smaller
+  if (!is.null(subtitle)) {
+    user_text <- shiny::tags$p(line_1, shiny::tags$small(subtitle))
+    user_header_height <- NULL
+  } else {
+    user_text <- shiny::tags$p(line_1)
+    user_header_height <- shiny::tags$script(shiny::HTML('$(".user-header").css("height", "145px")'));
+  }
+  
   # create user account menu
   userTag <- shiny::tagList(
     # menu toggle button
@@ -301,11 +318,12 @@ dashboardUser <- function(..., name = NULL, src = NULL, title = NULL,
       # user img in the menu
       shiny::tags$li(
         class = "user-header",
+        if(!is.null(user_header_height)) user_header_height,
         shiny::tags$img(src = src, class = "img-circle", alt = "User Image"),
-        shiny::tags$p(paste0(name, " - ", title), shiny::tags$small(subtitle))
+        user_text
       ),
       # menu body
-      shiny::tags$li(class = "user-body", ...),
+      if(length(list(...)) > 0) shiny::tags$li(class = "user-body", ...),
       # menu footer. Do not show if NULL
       if(!is.null(footer)) shiny::tags$li(class = "user-footer", footer)
     )


### PR DESCRIPTION
There have been situations where title and subtitle are not used. My proposed changes handle these situations. If there is a subtitle, it will add the hyphen between name and title, `Kyle - Dev`. Or if no title, it would just be `Kyle`.

If the subtitle is not used I use jquery to change the height from 175px to 145px so there isn't so much padding below the name.

I have found sometimes we just want to display a name and title in the dropdown menu and so the body content is not always used. If the body content is not used it will insert a white box. I added a `if(length(list(...)) > 0)` to the user body section so it will not create a white box if there is no content.

Excited to hear any thoughts or critiques on these changes, I have been using this customization for a few weeks now and thought this might be an improvement on the original :)