### PR TITLE
Don't statically copy `shiny::tabPanel` and `shiny::renderUI` at build time

### DIFF
--- a/R/dashboardControlbar.R
+++ b/R/dashboardControlbar.R
@@ -248,8 +248,9 @@ controlbarMenu <- function(..., id = NULL, selected = NULL) {
 #' @inheritParams shiny::tabPanel
 #' @export
 #' @rdname controlbar
-controlbarItem <- shiny::tabPanel
-
+controlbarItem <- function(title, ..., value = title, icon = NULL) {
+  shiny::tabPanel(title, ..., value = value, icon = icon)
+}
 
 
 

--- a/R/dashboardHeader.R
+++ b/R/dashboardHeader.R
@@ -374,7 +374,13 @@ userOutput <- function(id, tag = shiny::tags$li) {
 #'   and examples.
 #' @family user outputs
 #' @export
-renderUser <- shiny::renderUI
+renderUser <- function(expr, env = parent.frame(), quoted = FALSE, outputArgs = list()) {
+  if (!quoted) {
+    expr <- substitute(expr)
+    quoted <- TRUE
+  }
+  shiny::renderUI(expr, env = env, quoted = quoted, outputArgs = outputArgs)
+}
 
 # make R CMD check happy
 globalVariables("func")


### PR DESCRIPTION
With the upcoming Shiny 1.7.0 release candidate, the old previous code caused the following error in `R CMD check`:

```
W  checking dependencies in R code (509ms)
   '::' or ':::' import not declared from: 'bslib'
```

This is because the following line copies the function directly from the installed version of Shiny, and in Shiny 1.7.0, that function contains a call to `bslib::nav()`:

```
controlbarItem <- shiny::tabPanel
```


There are additional reasons that it is dangerous to copy objects from another package at build time, which is what that line does. It means that the object will be copied from the version of Shiny installed _when shinydashboardPlus was built_, but if the version of Shiny is later update, then shinydashboardPlus will still have the old version of the function copied from the old version of Shiny.

Please read https://r-pkgs.org/r.html#aliasing-a-function for more information about possible problems from copying functions at package build time.

If you could please merge and release a new version as soon as possible, we would appreciate it, as this is a blocker for the upcoming Shiny 1.7.0.